### PR TITLE
[Refactor] Google の Swift のコーディング規約に従って定数の命名の変更

### DIFF
--- a/iOS/Entities/IDPhoto/IDPhotoSizeVariant.swift
+++ b/iOS/Entities/IDPhoto/IDPhotoSizeVariant.swift
@@ -28,9 +28,9 @@ public enum IDPhotoSizeVariant: Int, CaseIterable {
     case w50_h50
     
     var photoSize: IDPhotoSize {
-        let GENERIC_MARGIN_TOP: Measurement<UnitLength> = .init(value: 4, unit: .millimeters)
+        let genericMarginTop: Measurement<UnitLength> = .init(value: 4, unit: .millimeters)
         
-        let GENERIC_FACE_HEIGHT_PERCENTAGE: Double = (60 / 100)
+        let genericFaceHeightPercentage: Double = (60 / 100)
         
         switch self {
 
@@ -69,81 +69,81 @@ public enum IDPhotoSizeVariant: Int, CaseIterable {
             let width: Measurement<UnitLength> = .init(value: 24, unit: .millimeters)
             let height: Measurement<UnitLength> = .init(value: 30, unit: .millimeters)
             
-            let faceHeight: Measurement<UnitLength> = .init(value: height.value * GENERIC_FACE_HEIGHT_PERCENTAGE, unit: .millimeters)
+            let faceHeight: Measurement<UnitLength> = .init(value: height.value * genericFaceHeightPercentage, unit: .millimeters)
             
-            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: GENERIC_MARGIN_TOP)
+            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: genericMarginTop)
             
         case .w25_h30:
             let width: Measurement<UnitLength> = .init(value: 25, unit: .millimeters)
             let height: Measurement<UnitLength> = .init(value: 30, unit: .millimeters)
             
-            let faceHeight: Measurement<UnitLength> = .init(value: height.value * GENERIC_FACE_HEIGHT_PERCENTAGE, unit: .millimeters)
+            let faceHeight: Measurement<UnitLength> = .init(value: height.value * genericFaceHeightPercentage, unit: .millimeters)
             
-            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: GENERIC_MARGIN_TOP)
+            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: genericMarginTop)
             
         case .w30_h30:
             let width: Measurement<UnitLength> = .init(value: 30, unit: .millimeters)
             let height: Measurement<UnitLength> = .init(value: 30, unit: .millimeters)
             
-            let faceHeight: Measurement<UnitLength> = .init(value: height.value * GENERIC_FACE_HEIGHT_PERCENTAGE, unit: .millimeters)
+            let faceHeight: Measurement<UnitLength> = .init(value: height.value * genericFaceHeightPercentage, unit: .millimeters)
             
-            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: GENERIC_MARGIN_TOP)
+            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: genericMarginTop)
             
         case .w30_h40:
             let width: Measurement<UnitLength> = .init(value: 30, unit: .millimeters)
             let height: Measurement<UnitLength> = .init(value: 40, unit: .millimeters)
             
-            let faceHeight: Measurement<UnitLength> = .init(value: height.value * GENERIC_FACE_HEIGHT_PERCENTAGE, unit: .millimeters)
+            let faceHeight: Measurement<UnitLength> = .init(value: height.value * genericFaceHeightPercentage, unit: .millimeters)
             
-            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: GENERIC_MARGIN_TOP)
+            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: genericMarginTop)
             
         case .w35_h45:
             let width: Measurement<UnitLength> = .init(value: 35, unit: .millimeters)
             let height: Measurement<UnitLength> = .init(value: 45, unit: .millimeters)
             
-            let faceHeight: Measurement<UnitLength> = .init(value: height.value * GENERIC_FACE_HEIGHT_PERCENTAGE, unit: .millimeters)
+            let faceHeight: Measurement<UnitLength> = .init(value: height.value * genericFaceHeightPercentage, unit: .millimeters)
             
-            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: GENERIC_MARGIN_TOP)
+            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: genericMarginTop)
             
         case .w40_h50:
             let width: Measurement<UnitLength> = .init(value: 40, unit: .millimeters)
             let height: Measurement<UnitLength> = .init(value: 50, unit: .millimeters)
             
-            let faceHeight: Measurement<UnitLength> = .init(value: height.value * GENERIC_FACE_HEIGHT_PERCENTAGE, unit: .millimeters)
+            let faceHeight: Measurement<UnitLength> = .init(value: height.value * genericFaceHeightPercentage, unit: .millimeters)
             
-            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: GENERIC_MARGIN_TOP)
+            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: genericMarginTop)
             
         case .w40_h55:
             let width: Measurement<UnitLength> = .init(value: 40, unit: .millimeters)
             let height: Measurement<UnitLength> = .init(value: 55, unit: .millimeters)
             
-            let faceHeight: Measurement<UnitLength> = .init(value: height.value * GENERIC_FACE_HEIGHT_PERCENTAGE, unit: .millimeters)
+            let faceHeight: Measurement<UnitLength> = .init(value: height.value * genericFaceHeightPercentage, unit: .millimeters)
             
-            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: GENERIC_MARGIN_TOP)
+            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: genericMarginTop)
             
         case .w40_h60:
             let width: Measurement<UnitLength> = .init(value: 40, unit: .millimeters)
             let height: Measurement<UnitLength> = .init(value: 60, unit: .millimeters)
             
-            let faceHeight: Measurement<UnitLength> = .init(value: height.value * GENERIC_FACE_HEIGHT_PERCENTAGE, unit: .millimeters)
+            let faceHeight: Measurement<UnitLength> = .init(value: height.value * genericFaceHeightPercentage, unit: .millimeters)
             
-            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: GENERIC_MARGIN_TOP)
+            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: genericMarginTop)
             
         case .w45_h60:
             let width: Measurement<UnitLength> = .init(value: 45, unit: .millimeters)
             let height: Measurement<UnitLength> = .init(value: 60, unit: .millimeters)
             
-            let faceHeight: Measurement<UnitLength> = .init(value: height.value * GENERIC_FACE_HEIGHT_PERCENTAGE, unit: .millimeters)
+            let faceHeight: Measurement<UnitLength> = .init(value: height.value * genericFaceHeightPercentage, unit: .millimeters)
             
-            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: GENERIC_MARGIN_TOP)
+            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: genericMarginTop)
             
         case .w50_h50:
             let width: Measurement<UnitLength> = .init(value: 50, unit: .millimeters)
             let height: Measurement<UnitLength> = .init(value: 50, unit: .millimeters)
             
-            let faceHeight: Measurement<UnitLength> = .init(value: height.value * GENERIC_FACE_HEIGHT_PERCENTAGE, unit: .millimeters)
+            let faceHeight: Measurement<UnitLength> = .init(value: height.value * genericFaceHeightPercentage, unit: .millimeters)
             
-            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: GENERIC_MARGIN_TOP)
+            return IDPhotoSize(width: width, height: height, faceHeight: faceHeight, marginTop: genericMarginTop)
         }
     }
 }

--- a/iOS/Scenes/IDPhotoDetail/IDPhotoDetailViewContainer.swift
+++ b/iOS/Scenes/IDPhotoDetail/IDPhotoDetailViewContainer.swift
@@ -319,7 +319,7 @@ extension IDPhotoDetailViewContainer {
             height: .init(value: idPhotoMillimetersHeight, unit: .millimeters)
         )
         
-        let printingIDPhotoCGSize: CGSize = printingIDPhotoActualSize.cgSize(pixelDensity: PrintPageRenderer.APPLE_PRINT_PIXEL_DENSITY)
+        let printingIDPhotoCGSize: CGSize = printingIDPhotoActualSize.cgSize(pixelDensity: PrintPageRenderer.applePrintPixelDensity)
         
         guard let createdIDPhotoFileURL: URL = parseCreatedIDPhotoFileURL() else { return }
         

--- a/iOS/Utilities/Printing/PrintPageRenderer.swift
+++ b/iOS/Utilities/Printing/PrintPageRenderer.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class PrintPageRenderer: UIPrintPageRenderer {
-    static let APPLE_PRINT_PIXEL_DENSITY: Double = 72
+    static let applePrintPixelDensity: Double = 72
     
     var onDrawPage: ((Int, CGRect) -> Void)?
     var onDrawHeaderForPage: ((Int, CGRect) -> Void)?


### PR DESCRIPTION
## 概要

定数系の命名を、React のようにアッパースネークケースで書いていたが、Google Style Guide および Swift の標準的な書き方としてこれは誤りであることを最近知ったので、その命名修正

https://google.github.io/swift/#static-and-class-properties