### PR TITLE
fix: iOS 26 において、証明写真作成/編集画面 でチェックマークボタンを押すと「失敗しました」と表示されて保存ができない不具合が発生していたので修正

### DIFF
--- a/iOS/Scenes/CreateIDPhoto/CreateIDPhotoViewContainer.swift
+++ b/iOS/Scenes/CreateIDPhoto/CreateIDPhotoViewContainer.swift
@@ -336,6 +336,7 @@ struct CreateIDPhotoViewContainer: View {
 
                 let savedFileURL: URL? = try saveImageToSpecifiedDirectory(
                     ciImage: croppedPaintedPhotoCIImage,
+                    colorSpace: sourcePhotoCIImage.colorSpace ?? CGColorSpaceCreateDeviceRGB(),
                     fileName: saveFileName,
                     fileType: saveFileUTType,
                     to: saveDestinationDirectoryURL
@@ -760,40 +761,41 @@ extension CreateIDPhotoViewContainer {
     
     func saveImageToSpecifiedDirectory(
         ciImage: CIImage,
+        colorSpace: CGColorSpace,
         fileName: String,
         fileType: UTType,
         to saveDestinationDirectoryURL: URL
     ) throws -> URL? {
-        
+
         let saveFilePathURL: URL = saveDestinationDirectoryURL
             .appendingPathComponent(fileName, conformingTo: fileType)
-        
+
         let ciContext: CIContext = .init()
-        
+
         do {
             if fileType == .jpeg {
                 let jpegData: Data? = ciImage.jpegData(
                     ciContext: ciContext,
-                    colorSpace: ciImage.colorSpace ?? CGColorSpaceCreateDeviceRGB()
+                    colorSpace: colorSpace
                 )
-                
+
                 guard let jpegData = jpegData else { return nil }
-                
+
                 try jpegData.write(to: saveFilePathURL)
-                
+
                 return saveFilePathURL
             }
-            
+
             let heicData: Data? = ciImage.heifData(
                 ciContext: ciContext,
                 format: .RGBA8,
-                colorSpace: ciImage.colorSpace ?? CGColorSpaceCreateDeviceRGB()
+                colorSpace: colorSpace
             )
-            
+
             guard let heicData = heicData else { return nil }
-            
+
             try heicData.write(to: saveFilePathURL)
-            
+
             return saveFilePathURL
         } catch {
             throw error

--- a/iOS/Scenes/EditIDPhoto/EditIDPhotoViewContainer.swift
+++ b/iOS/Scenes/EditIDPhoto/EditIDPhotoViewContainer.swift
@@ -461,6 +461,7 @@ struct EditIDPhotoViewContainer: View {
                     
                     let createdNewIDPhotoURL: URL?  = try createImageFile(
                         image: croppedPaintedIDPhoto,
+                        colorSpace: sourcePhotoCIImage.colorSpace ?? CGColorSpaceCreateDeviceRGB(),
                         fileName: originalCreatedIDPhotoFileBaseName,
                         fileType: originalCreatedIDPhotoFileUTType,
                         saveDestination: fileManager.temporaryDirectory
@@ -922,35 +923,36 @@ extension EditIDPhotoViewContainer {
     func createImageFile(
         fileManager: FileManager = .default,
         image: CIImage,
+        colorSpace: CGColorSpace,
         fileName: String,
         fileType: UTType,
         saveDestination: URL
     ) throws -> URL? {
         do {
             let ciContext: CIContext = .init()
-            
+
             let filePathURL: URL = saveDestination
                 .appendingPathComponent(fileName, conformingTo: fileType)
-            
+
             if fileType == .jpeg {
                 let jpegData: Data? = image.jpegData(
                     ciContext: ciContext,
-                    colorSpace: image.colorSpace ?? CGColorSpaceCreateDeviceRGB()
+                    colorSpace: colorSpace
                 )
-                
+
                 try jpegData?.write(to: filePathURL)
-                
+
                 return filePathURL
             }
-            
+
             let heifData: Data? = image.heifData(
                 ciContext: ciContext,
                 format: .RGBA8,
-                colorSpace: image.colorSpace ?? CGColorSpaceCreateDeviceRGB()
+                colorSpace: colorSpace
             )
-            
+
             try heifData?.write(to: filePathURL)
-            
+
             return filePathURL
         } catch {
             throw error


### PR DESCRIPTION
表題の通り